### PR TITLE
Fix: Types Location on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A nicely formatted html transcript generator for discord.js.",
   "main": "dist/index.js",
   "homepage": "https://github.com/ItzDerock/discord-html-transcripts",
-  "types": "./index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",


### PR DESCRIPTION
### Issue:
 When importing the package the types are not being read properly.

### Fix:
 Change types location from "./index.d.ts" to "./dist/index.d.ts"

Because it seems after it's compiled, the "index.d.ts" lives in the dist file.