### PR TITLE
Make alike Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /dist
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Discord HTML Transcripts is a node.js module to generate nice looking HTML trans
 HTML Template stolen from [DiscordChatExporter](https://github.com/Tyrrrz/DiscordChatExporter).
 
 ## Example Output
-![output](https://img.derock.dev/5f5q0a.png)
+![output](https://img.derock.dev/1wnf9q.gif)
 
 ## Usage
 ### Example usage using the built in message fetcher.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-html-transcripts",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A nicely formatted html transcript generator for discord.js.",
   "main": "dist/index.js",
   "homepage": "https://github.com/ItzDerock/discord-html-transcripts",

--- a/src/exporthtml.ts
+++ b/src/exporthtml.ts
@@ -10,6 +10,15 @@ import { minify }        from 'html-minifier';
 import { internalGenerateOptions, ObjectType, ReturnTypes } from './types';
 const template = fs.readFileSync(path.join(__dirname, 'template.html'), 'utf8');
 
+let options = {
+	weekday: 'long',
+	year: 'numeric',
+	month: 'short',
+	day: 'numeric',
+	hour: '2-digit',
+	minute: '2-digit',
+};
+
 // copilot helped so much here
 // copilot smart 🧠
 
@@ -100,7 +109,13 @@ function generateTranscript<T extends ReturnTypes>(messages: discord.Message[], 
         // timestamp
         const timestamp = document.createElement('span');
         timestamp.classList.add('chatlog__timestamp');
-        timestamp.textContent = message.createdAt.toLocaleString();
+        const yyyy = message.createdAt.getFullYear();
+        let mm = message.createdAt.getMonth() + 1; // Months start at 0!
+        let dd = message.createdAt.getDate();
+        if (dd < 10) dd = '0' + dd;
+        if (mm < 10) mm = '0' + mm;
+        timestamp.textContent = `${dd}/${mm}/${yyyy}`;
+        timestamp.title = he.escape(message.createdAt.toLocaleTimeString("en-us", options))
 
         content.appendChild(timestamp);
 
@@ -108,7 +123,6 @@ function generateTranscript<T extends ReturnTypes>(messages: discord.Message[], 
         messageContent.classList.add('chatlog__message');
         messageContent.setAttribute('data-message-id', message.id);
         messageContent.setAttribute('id', `message-${message.id}`);
-        messageContent.title = `Message sent: ${message.createdAt.toLocaleString()}`;
 
         // message content
         if(message.content) {

--- a/src/exporthtml.ts
+++ b/src/exporthtml.ts
@@ -10,7 +10,7 @@ import { minify }        from 'html-minifier';
 import { internalGenerateOptions, ObjectType, ReturnTypes } from './types';
 const template = fs.readFileSync(path.join(__dirname, 'template.html'), 'utf8');
 
-let options = {
+let options: Intl.DateTimeFormatOptions = {
 	weekday: 'long',
 	year: 'numeric',
 	month: 'short',
@@ -18,6 +18,7 @@ let options = {
 	hour: '2-digit',
 	minute: '2-digit',
 };
+export const date = { options };
 
 // copilot helped so much here
 // copilot smart 🧠
@@ -110,12 +111,10 @@ function generateTranscript<T extends ReturnTypes>(messages: discord.Message[], 
         const timestamp = document.createElement('span');
         timestamp.classList.add('chatlog__timestamp');
         const yyyy = message.createdAt.getFullYear();
-        let mm = message.createdAt.getMonth() + 1; // Months start at 0!
-        let dd = message.createdAt.getDate();
-        if (dd < 10) dd = '0' + dd;
-        if (mm < 10) mm = '0' + mm;
+        const mm = message.createdAt.getMonth() + 1;
+        const dd = message.createdAt.getUTCDate();
         timestamp.textContent = `${dd}/${mm}/${yyyy}`;
-        timestamp.title = he.escape(message.createdAt.toLocaleTimeString("en-us", options))
+        timestamp.title = he.escape(message.createdAt.toLocaleTimeString("en-us", date.options))
 
         content.appendChild(timestamp);
 

--- a/src/exporthtml.ts
+++ b/src/exporthtml.ts
@@ -126,7 +126,7 @@ function generateTranscript<T extends ReturnTypes>(messages: discord.Message[], 
 
         // message content
         if(message.content) {
-            if (validateURL(message.content) == true) {
+            if (validateURL(message.content)) {
                 var link = document.createElement('a');
                 link.classList.add('chatlog__content');
                 link.href = message.content;
@@ -553,13 +553,7 @@ function formatBytes(bytes: number, decimals = 2) {
 }
 
 function validateURL(url: string) {
-    var regex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
-
-    if (!regex.test(url)) {
-        return false;
-    } else {
-        return true;
-    }
+    return !(/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi.test(url));
 }
 
 export default generateTranscript;

--- a/src/exporthtml.ts
+++ b/src/exporthtml.ts
@@ -126,7 +126,7 @@ function generateTranscript<T extends ReturnTypes>(messages: discord.Message[], 
 
         // message content
         if(message.content) {
-            if (message.content.startsWith('http://') || message.content.startsWith('https://')) {
+            if (validateURL(message.content) == true) {
                 var link = document.createElement('a');
                 link.classList.add('chatlog__content');
                 link.href = message.content;
@@ -550,6 +550,16 @@ function formatBytes(bytes: number, decimals = 2) {
     const i = Math.floor(Math.log(bytes) / Math.log(k));
 
     return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
+function validateURL(url: string) {
+    var regex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
+
+    if (!regex.test(url)) {
+        return false;
+    } else {
+        return true;
+    }
 }
 
 export default generateTranscript;

--- a/src/exporthtml.ts
+++ b/src/exporthtml.ts
@@ -126,23 +126,32 @@ function generateTranscript<T extends ReturnTypes>(messages: discord.Message[], 
 
         // message content
         if(message.content) {
-            const messageContentContent = document.createElement('div');
-            messageContentContent.classList.add('chatlog__content');
+            if (message.content.startsWith('http://') || message.content.startsWith('https://')) {
+                var link = document.createElement('a');
+                link.classList.add('chatlog__content');
+                link.href = message.content;
+                link.target = '_blank';
+                link.textContent = message.content;
+                messageContent.appendChild(link);
+            } else {
+                const messageContentContent = document.createElement('div');
+                messageContentContent.classList.add('chatlog__content');
 
-            const messageContentContentMarkdown = document.createElement('div');
-            messageContentContentMarkdown.classList.add('markdown');
+                const messageContentContentMarkdown = document.createElement('div');
+                messageContentContentMarkdown.classList.add('markdown');
 
-            const messageContentContentMarkdownSpan = document.createElement('span');
-            messageContentContentMarkdownSpan.classList.add('preserve-whitespace');
-            messageContentContentMarkdownSpan.innerHTML = formatContent(
-                message.content,
-                channel,
-                message.webhookId !== null
-            );
-
-            messageContentContentMarkdown.appendChild(messageContentContentMarkdownSpan);
-            messageContentContent.appendChild(messageContentContentMarkdown);
-            messageContent.appendChild(messageContentContent);
+                const messageContentContentMarkdownSpan = document.createElement('span');
+                messageContentContentMarkdownSpan.classList.add('preserve-whitespace');
+                messageContentContentMarkdownSpan.innerHTML = formatContent(
+                    message.content,
+                    channel,
+                    message.webhookId !== null
+                );
+                
+                messageContentContentMarkdown.appendChild(messageContentContentMarkdownSpan);
+                messageContentContent.appendChild(messageContentContentMarkdown);
+                messageContent.appendChild(messageContentContent);
+            }
         }
 
         // message attachments

--- a/src/exporthtml.ts
+++ b/src/exporthtml.ts
@@ -552,7 +552,7 @@ function formatBytes(bytes: number, decimals = 2) {
 }
 
 function validateURL(url: string) {
-    return !(/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi.test(url));
+    return /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi.test(url);
 }
 
 export default generateTranscript;

--- a/src/template.html
+++ b/src/template.html
@@ -43,6 +43,8 @@
             font-family: "Whitney", "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-size: 17px;
             font-weight: 400;
+            margin: 0;
+            overflow-x: hidden;
         }
 
         a {
@@ -126,8 +128,8 @@
         .mention {
             border-radius: 3px;
             padding: 0 2px;
-            color: #7289da;
-            background-color: rgba(114, 137, 218, .1);
+            color: #dee0fc;
+            background-color: rgb(89, 102, 243, 0.3);
             font-weight: 500;
         }
 
@@ -156,7 +158,7 @@
 
         .preamble {
             display: grid;
-            margin: 0 0.3em 0.6em 0.3em;
+            margin: 1em;
             max-width: 100%;
             grid-template-columns: auto 1fr;
         }
@@ -181,6 +183,7 @@
             0% {
                 border-radius: 50%;
             }
+
             100% {
                 border-radius: 25%;
             }
@@ -190,6 +193,7 @@
             0% {
                 border-radius: 25%;
             }
+
             100% {
                 border-radius: 50%;
             }
@@ -214,33 +218,51 @@
         }
 
         .chatlog-divider {
-            height:1px;
-            border-width:0;
-            color:gray;
+            height: 1px;
+            border-width: 0;
+            color: gray;
             background-color: #42464d;
         }
 
         .chatlog {
             max-width: 100%;
+            margin-bottom: 1.8em;
         }
 
         .chatlog__message-group {
             display: grid;
-            margin: 0 0.6em;
-            padding: 0.9em 0;
+            padding: 0.1em 0;
             grid-template-columns: auto 1fr;
+            margin-top: 1.0625rem;
         }
 
         .chatlog__message-group:hover {
-            background-color: #32353b;
+            background-color: rgba(4, 4, 5, 0.07);
+        }
+
+        .chatlog__message-group--highlighted {
+            background-color: rgba(88, 101, 242, 0);
+            animation: highlight 1.5s;
+        }
+
+        @keyframes highlight {
+            0% {
+                background-color: rgba(88, 101, 242, 0.2);
+            }
+
+            100% {
+                background-color: rgba(88, 101, 242, 0);
+            }
         }
 
         .chatlog__reference-symbol {
             grid-column: 1;
-            margin: 8px 4px 4px 28px;
+            margin: 8px -1em 0 2.2em;
             border-left: 2px solid #4f545c;
             border-top: 2px solid #4f545c;
-            border-radius: 8px 0 0 0;
+            border-radius: 6px 0 0 0;
+            width: 32px;
+            height: 11px;
         }
 
         .chatlog__reference {
@@ -253,6 +275,7 @@
             text-overflow: ellipsis;
             align-items: center;
             color: #b5b6b8;
+            margin-left: 1.2em;
         }
 
         .chatlog__reference-avatar {
@@ -311,24 +334,28 @@
             border-radius: 50%;
             width: 40px;
             height: 40px;
-            margin-left: 15px;
+            margin-left: 1em;
+            margin-top: .25rem;
         }
 
         .chatlog__messages {
             grid-column: 2;
             min-width: 50%;
+            padding-left: 1em;
         }
 
         .chatlog__author-name {
             font-weight: 500;
             color: #ffffff;
-            margin-left: 15px;
+            font-size: 16.3px;
         }
 
         .chatlog__timestamp {
             margin-left: 0.3em;
-            font-size: 0.75em;
-            color: rgba(255, 255, 255, 0.2);
+            font-size: 0.75rem;
+            line-height: 1.375rem;
+            color: #a3a6aa;
+            vertical-align: baseline;
         }
 
         .chatlog__message {
@@ -338,10 +365,6 @@
             transition: background-color 1s ease;
         }
 
-        .chatlog__message--highlighted {
-            background-color: rgba(114, 137, 218, 0.2);
-        }
-
         .chatlog__message--pinned {
             background-color: rgba(249, 168, 37, 0.05);
         }
@@ -349,7 +372,6 @@
         .chatlog__content {
             font-size: 0.95em;
             word-wrap: break-word;
-            margin-left: 15px;
         }
 
         .chatlog__edited-timestamp {
@@ -364,7 +386,6 @@
             margin-top: 0.3em;
             border-radius: 3px;
             overflow: hidden;
-            margin-left: 15px;
         }
 
         .chatlog__attachment--hidden {
@@ -448,7 +469,6 @@
             display: flex;
             margin-top: 0.3em;
             max-width: 520px;
-            margin-left: 15px;
         }
 
         .chatlog__embed-color-pill {
@@ -465,9 +485,8 @@
         .chatlog__embed-content-container {
             display: flex;
             flex-direction: column;
-            padding: 0.5em 0.6em;
-            background-color: rgba(46, 48, 54, 0.3);
-            border: 1px solid rgba(46, 48, 54, 0.6);
+            padding: .5rem 1rem 1rem .75rem;
+            background-color: #2f3136;
             border-top-right-radius: 3px;
             border-bottom-right-radius: 3px;
         }
@@ -505,16 +524,18 @@
         }
 
         .chatlog__embed-title {
-            margin-bottom: 0.2em;
-            font-size: 0.875em;
+            font-size: 1rem;
             font-weight: 600;
             color: #ffffff;
+            margin-top: 8px;
         }
 
         .chatlog__embed-description {
-            font-weight: 500;
-            font-size: 0.85em;
             color: #dcddde;
+            margin-top: 8px;
+            font-size: 0.875rem;
+            line-height: 1.125rem;
+            font-weight: 400;
         }
 
         .chatlog__embed-fields {
@@ -538,19 +559,23 @@
         }
 
         .chatlog__embed-field-name {
-            margin-bottom: 0.2em;
+            color: white;
+            font-size: 0.875rem;
+            line-height: 1.125rem;
+            min-width: 0;
             font-weight: 600;
-            color: #ffffff;
+            margin-bottom: 2px;
         }
 
         .chatlog__embed-field-value {
-            font-weight: 500;
+            font-weight: 400;
             color: #dcddde;
         }
 
         .chatlog__embed-thumbnail {
             flex: 0;
-            margin-left: 1.2em;
+            margin-left: 16px;
+            margin-top: 8px;
             max-width: 80px;
             max-height: 80px;
             border-radius: 3px;
@@ -661,12 +686,12 @@
 
     <script>
         function scrollToMessage(event, id) {
-            var element = document.getElementById('message-' + id);
+            var element = document.getElementById('message-' + id).parentNode.parentNode;
 
             if (element) {
                 event.preventDefault();
 
-                element.classList.add('chatlog__message--highlighted');
+                element.classList.add('chatlog__message-group--highlighted');
 
                 window.scrollTo({
                     top: element.getBoundingClientRect().top - document.body.getBoundingClientRect().top - (window.innerHeight / 2),
@@ -674,7 +699,7 @@
                 });
 
                 window.setTimeout(function () {
-                    element.classList.remove('chatlog__message--highlighted');
+                    element.classList.remove('chatlog__message-group--highlighted');
                 }, 2000);
             }
         }

--- a/src/template.html
+++ b/src/template.html
@@ -38,7 +38,7 @@
         }
 
         body {
-            background-color: #36393e;
+            background-color: #36393f;
             color: #dcddde;
             font-family: "Whitney", "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-size: 17px;
@@ -168,6 +168,31 @@
         .preamble__guild-icon {
             max-width: 88px;
             max-height: 88px;
+            animation: border-radius-animation-out 0.25s ease-in-out;
+            border-radius: 50%;
+        }
+
+        .preamble__guild-icon:hover {
+            animation: border-radius-animation-in 0.25s ease-in-out;
+            border-radius: 25%;
+        }
+
+        @keyframes border-radius-animation-in {
+            0% {
+                border-radius: 50%;
+            }
+            100% {
+                border-radius: 25%;
+            }
+        }
+
+        @keyframes border-radius-animation-out {
+            0% {
+                border-radius: 25%;
+            }
+            100% {
+                border-radius: 50%;
+            }
         }
 
         .preamble__entries-container {
@@ -180,8 +205,19 @@
             color: #ffffff;
         }
 
+        .preamble__entry#guildname {
+            font-weight: bold;
+        }
+
         .preamble__entry--small {
             font-size: 1em;
+        }
+
+        .chatlog-divider {
+            height:1px;
+            border-width:0;
+            color:gray;
+            background-color: #42464d;
         }
 
         .chatlog {
@@ -192,8 +228,11 @@
             display: grid;
             margin: 0 0.6em;
             padding: 0.9em 0;
-            border-top: 1px solid rgba(255, 255, 255, 0.1);
             grid-template-columns: auto 1fr;
+        }
+
+        .chatlog__message-group:hover {
+            background-color: #32353b;
         }
 
         .chatlog__reference-symbol {
@@ -272,6 +311,7 @@
             border-radius: 50%;
             width: 40px;
             height: 40px;
+            margin-left: 15px;
         }
 
         .chatlog__messages {
@@ -282,6 +322,7 @@
         .chatlog__author-name {
             font-weight: 500;
             color: #ffffff;
+            margin-left: 15px;
         }
 
         .chatlog__timestamp {
@@ -308,11 +349,13 @@
         .chatlog__content {
             font-size: 0.95em;
             word-wrap: break-word;
+            margin-left: 15px;
         }
 
         .chatlog__edited-timestamp {
             margin-left: 0.15em;
             font-size: 0.8em;
+            color: rgba(255, 255, 255, 0.2);
         }
 
         .chatlog__attachment {
@@ -398,10 +441,6 @@
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
-        }
-
-        .chatlog__edited-timestamp {
-            color: rgba(255, 255, 255, 0.2);
         }
 
         .chatlog__embed {
@@ -676,6 +715,8 @@
             <div class="preamble__entry" id="ticketname">Channel Name Here</div>
         </div>
     </div>
+
+    <hr class="chatlog-divider">
 
     <div class="chatlog" id="chatlog">
 

--- a/src/template.html
+++ b/src/template.html
@@ -237,7 +237,7 @@
 
         .chatlog__reference-symbol {
             grid-column: 1;
-            margin: 8px 4px 4px 18px;
+            margin: 8px 4px 4px 28px;
             border-left: 2px solid #4f545c;
             border-top: 2px solid #4f545c;
             border-radius: 8px 0 0 0;
@@ -364,6 +364,7 @@
             margin-top: 0.3em;
             border-radius: 3px;
             overflow: hidden;
+            margin-left: 15px;
         }
 
         .chatlog__attachment--hidden {
@@ -447,6 +448,7 @@
             display: flex;
             margin-top: 0.3em;
             max-width: 520px;
+            margin-left: 15px;
         }
 
         .chatlog__embed-color-pill {


### PR DESCRIPTION
This PR:
* Adds animation to the guild icon, just like in Discord.
* Made a few changes to the color pallet.
* Removed unnecessary borders after each message in chat log, instead added a darker background effect upon hover.
* Made Guild Name Bold.
* Made changes to timestamp to make it alike Discord.
* Added a divider between guild information and chat log + Few more changes…
* Bumped version from `2.4.2` to `2.4.3`

Screenshots:
* Before
![image](https://user-images.githubusercontent.com/79590499/168423428-a278613a-d41f-48d8-9cc9-cb984437a9fb.png)
* After
![En845nRqQA](https://user-images.githubusercontent.com/79590499/168423412-7db21ace-5088-4306-a774-cac0ab3c495d.gif)

Thank you!
