### PR TITLE
fix: Respect `limit` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Both methods of generating a transcript allow for an option object as the last p
 
 ```js
 const attachment = await discordTranscripts.createTranscript(channel, {
-    limit: -1, // Max amount of messages to fetch.
+    limit: -1, // Max amount of messages to fetch. `-1` recursively fetches. Default is 100.
     returnType: 'attachment', // Valid options: 'buffer' | 'string' | 'attachment' Default: 'attachment' OR use the enum ExportReturnType
     filename: 'transcript.html', // Only valid with returnType is 'attachment'. Name of attachment.
     saveImages: false, // Download all images and include the image data in the HTML (allows viewing the image even after it has been deleted) (! WILL INCREASE FILE SIZE !)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Both methods of generating a transcript allow for an option object as the last p
 
 ```js
 const attachment = await discordTranscripts.createTranscript(channel, {
-    limit: -1, // Max amount of messages to fetch. `-1` recursively fetches. Default is 100.
+    limit: -1, // Max amount of messages to fetch. `-1` recursively fetches.
     returnType: 'attachment', // Valid options: 'buffer' | 'string' | 'attachment' Default: 'attachment' OR use the enum ExportReturnType
     filename: 'transcript.html', // Only valid with returnType is 'attachment'. Name of attachment.
     saveImages: false, // Download all images and include the image data in the HTML (allows viewing the image even after it has been deleted) (! WILL INCREASE FILE SIZE !)

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,29 +84,33 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
   }
 
   // fetch messages
-  const allMessages: Message[] = [];
+  let allMessages: Message[] = [];
   let lastMessageId: string | undefined;
+  const limit = options.limit ?? 100;
 
   // until there are no more messages, keep fetching
   // eslint-disable-next-line no-constant-condition
   while (true) {
     // create fetch options
-    const options = { limit: 100, before: lastMessageId };
-    if (!lastMessageId) delete options.before;
+    const fetchLimitOptions = { limit: 100, before: lastMessageId };
+    if (!lastMessageId) delete fetchLimitOptions.before;
 
     // fetch messages
-    const messages = await channel.messages.fetch(options);
+    const messages = await channel.messages.fetch(fetchLimitOptions);
 
     // add the messages to the array
     allMessages.push(...messages.values());
-    lastMessageId = messages.last()?.id;
+    lastMessageId = messages.lastKey();
 
     // if there are no more messages, break
     if (messages.size < 100) break;
 
     // if the limit has been reached, break
-    if (allMessages.length >= (options.limit ?? Infinity)) break;
+    if (allMessages.length >= (limit === -1 ? Infinity : limit)) break;
   }
+
+  if (limit !== -1 && limit < allMessages.length)
+    allMessages = allMessages.slice(0, limit);
 
   // generate the transcript
   return generateFromMessages<T>(allMessages.reverse(), channel, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,8 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
   // fetch messages
   let allMessages: Message[] = [];
   let lastMessageId: string | undefined;
-  const limit = options.limit ?? 100;
+  const { limit } = options;
+  const resolvedLimit = typeof limit === "undefined" || limit === -1 ? Infinity : limit;
 
   // until there are no more messages, keep fetching
   // eslint-disable-next-line no-constant-condition
@@ -106,10 +107,10 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
     if (messages.size < 100) break;
 
     // if the limit has been reached, break
-    if (allMessages.length >= (limit === -1 ? Infinity : limit)) break;
+    if (allMessages.length >= resolvedLimit) break;
   }
 
-  if (limit !== -1 && limit < allMessages.length)
+  if (resolvedLimit < allMessages.length)
     allMessages = allMessages.slice(0, limit);
 
   // generate the transcript

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,6 @@ export type CreateTranscriptOptions<T extends ExportReturnType> = Partial<
   GenerateFromMessagesOptions<T> & {
     /**
      * The max amount of messages to fetch. Use `-1` to recursively fetch.
-     * @default 100
      */
     limit: number;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,8 @@ export type GenerateFromMessagesOptions<T extends ExportReturnType> = Partial<{
 export type CreateTranscriptOptions<T extends ExportReturnType> = Partial<
   GenerateFromMessagesOptions<T> & {
     /**
-     * The max amount of messages to fetch
+     * The max amount of messages to fetch. Use `-1` to recursively fetch.
+     * @default 100
      */
     limit: number;
   }


### PR DESCRIPTION
Resolves #87 & resolves #81 by respecting the `limit` option. `-1`'s use is properly documented.

In addition, a sensible default of `100` was made if no `limit` was supplied.

