### PR TITLE
fix: allow discord.js v15.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This module can format the following:
 - Mentions
 - Threads
 
-**This module is designed to work with [discord.js](https://discord.js.org/#/) v14 _only_. If you need v13 support, roll back to v2.X.X**
+**This module is designed to work with [discord.js](https://discord.js.org/#/) v14/v15 _only_. If you need v13 support, roll back to v2.X.X**
 
 Styles from [@derockdev/discord-components](https://github.com/ItzDerock/discord-components).  
 Behind the scenes, this package uses React SSR to generate a static site.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "undici": "^5.21.0"
   },
   "peerDependencies": {
-    "discord.js": "^14.0.0"
+    "discord.js": "^14.0.0 || ^15.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ import {
 } from './types';
 
 // version check
-if (version.split('.')[0] !== '14') {
+const versionPrefix = version.split('.')[0];
+
+if (versionPrefix !== '14' && versionPrefix !== '15') {
   console.error(
-    `[discord-html-transcripts] Versions v3.x.x of discord-html-transcripts are only compatible with js v14.x.x, and you are using v${version}.` +
-      `    Please install discord-html-transcripts v2.x.x using "npm install discord-html-transcripts@^2".`
+    `[discord-html-transcripts] Versions v3.x.x of discord-html-transcripts are only compatible with discord.js v14.x.x and v15.x.x, and you are using v${version}.` +
+      `    For v13.x.x support, please install discord-html-transcripts v2.x.x using "npm install discord-html-transcripts@^2".`
   );
   process.exit(1);
 }


### PR DESCRIPTION
Discord.js development is now in the v15 stage, and this package still functions in that version. This PR allows v15.x.x to be used, and clarifies the warning message if not using v14/v15. It also updates the README to reflect that.