### PR TITLE
feat: allow server-side hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ const attachment = await discordTranscripts.createTranscript(channel, {
       resolveUser: (userId: string) => Awaitable<User | null>,
       resolveRole: (roleId: string) => Awaitable<Role | null>
     },
-    poweredBy: true // Whether to include the "Powered by discord-html-transcripts" footer
+    poweredBy: true, // Whether to include the "Powered by discord-html-transcripts" footer
+    ssr: true // Whether to hydrate the html server-side
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@derockdev/discord-components-core": "^3.6.0",
-    "@derockdev/discord-components-react": "^3.6.0",
+    "@derockdev/discord-components-core": "^3.6.1",
+    "@derockdev/discord-components-react": "^3.6.1",
     "discord-markdown-parser": "~1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@derockdev/discord-components-core": "^3.5.3",
-    "@derockdev/discord-components-react": "^3.5.3",
+    "@derockdev/discord-components-core": "^3.6.0",
+    "@derockdev/discord-components-react": "^3.6.0",
     "discord-markdown-parser": "~1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,12 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@derockdev/discord-components-core':
-    specifier: ^3.5.3
-    version: 3.5.3
+    specifier: ^3.6.0
+    version: 3.6.0
   '@derockdev/discord-components-react':
-    specifier: ^3.5.3
-    version: 3.5.3(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^3.6.0
+    version: 3.6.0(react-dom@18.2.0)(react@18.2.0)
   discord-markdown-parser:
     specifier: ~1.1.0
     version: 1.1.0
@@ -80,27 +76,27 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@derockdev/discord-components-core@3.5.3:
-    resolution: {integrity: sha512-zTe/01obW1DcxiQkFsYj9Ub5O0XHpJg8ceIfWLj9jvAICQqu3HNmDsta6OiVLOxXNankAgaO4Wh8OBXlEFsG8g==}
+  /@derockdev/discord-components-core@3.6.0:
+    resolution: {integrity: sha512-wxjJs0ous1mKasLF0f6xUHTuZQWdRvob55SyrlNqJTeZVBMSwtiIU8qH/e2ssBJu6KOl67z0+YqwaGyyjEs0rg==}
     engines: {node: '>=v14.0.0'}
     dependencies:
-      '@stencil/core': 2.22.2
+      '@stencil/core': 3.4.2
       clsx: 1.2.1
       hex-to-rgba: 2.0.1
       highlight.js: 11.7.0
     dev: false
 
-  /@derockdev/discord-components-react@3.5.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-9MSczJdnwqgPyEU39UfEBfHpfQ6jG5IUytz3D+zwvp5RVPYAUCD2Ko30TPkMoJhQdP0QoEsx09ravfxNINH/lw==}
+  /@derockdev/discord-components-react@3.6.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GjXMyH+rte84eAAQuSSmdPFxdLHnnxe4a0G0yY949DBB5az2jEtPveK299sfQ4ANZJJgEr8eUfoKOL4gwd30Tw==}
     engines: {node: '>=v14.0.0'}
     peerDependencies:
       react: 16.8.x || 17.x || 18.x
       react-dom: 16.8.x || 17.x || 18.x
     dependencies:
-      '@derockdev/discord-components-core': 3.5.3
+      '@derockdev/discord-components-core': 3.6.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.4.1
+      tslib: 2.6.1
     dev: false
 
   /@discordjs/builders@1.6.4:
@@ -258,9 +254,9 @@ packages:
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: true
 
-  /@stencil/core@2.22.2:
-    resolution: {integrity: sha512-r+vbxsGNcBaV1VDOYW25lv4QfXTlNoIb5GpUX7rZ+cr59yqYCZC5tlV+IzX6YgHKW62ulCc9M3RYtTfHtNbNNw==}
-    engines: {node: '>=12.10.0', npm: '>=6.0.0'}
+  /@stencil/core@3.4.2:
+    resolution: {integrity: sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ==}
+    engines: {node: '>=14.10.0', npm: '>=6.0.0'}
     hasBin: true
     dev: false
 
@@ -1502,13 +1498,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib@2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: false
-
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
-    dev: true
 
   /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -1623,3 +1614,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,11 +2,11 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@derockdev/discord-components-core':
-    specifier: ^3.6.0
-    version: 3.6.0
+    specifier: ^3.6.1
+    version: 3.6.1
   '@derockdev/discord-components-react':
-    specifier: ^3.6.0
-    version: 3.6.0(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^3.6.1
+    version: 3.6.1(react-dom@18.2.0)(react@18.2.0)
   discord-markdown-parser:
     specifier: ~1.1.0
     version: 1.1.0
@@ -76,8 +76,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@derockdev/discord-components-core@3.6.0:
-    resolution: {integrity: sha512-wxjJs0ous1mKasLF0f6xUHTuZQWdRvob55SyrlNqJTeZVBMSwtiIU8qH/e2ssBJu6KOl67z0+YqwaGyyjEs0rg==}
+  /@derockdev/discord-components-core@3.6.1:
+    resolution: {integrity: sha512-qLcoab2Olui1IzJavnPzMgZzopWU21D3VDthkFgzZyiID4C5+OiSWx6ZNxz6wnMKfv/253AsXg8opdCwoRJKgg==}
     engines: {node: '>=v14.0.0'}
     dependencies:
       '@stencil/core': 3.4.2
@@ -86,14 +86,14 @@ packages:
       highlight.js: 11.7.0
     dev: false
 
-  /@derockdev/discord-components-react@3.6.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-GjXMyH+rte84eAAQuSSmdPFxdLHnnxe4a0G0yY949DBB5az2jEtPveK299sfQ4ANZJJgEr8eUfoKOL4gwd30Tw==}
+  /@derockdev/discord-components-react@3.6.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+EIHAo5wgXbVwJVgsRohi5/ZcWwrzzCPlV45c1lDL5iOvuuHDZKuPXJdUCdxUJBUpd2zxhcvjBXEZIlJqTe+sA==}
     engines: {node: '>=v14.0.0'}
     peerDependencies:
       react: 16.8.x || 17.x || 18.x
       react-dom: 16.8.x || 17.x || 18.x
     dependencies:
-      '@derockdev/discord-components-core': 3.6.0
+      '@derockdev/discord-components-core': 3.6.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.1

--- a/src/generator/index.tsx
+++ b/src/generator/index.tsx
@@ -11,7 +11,7 @@ import path from 'path';
 import { renderToString } from '@derockdev/discord-components-core/hydrate';
 
 // read the package.json file and get the @derockdev/discord-components-core version
-let discordComponentsVersion = '^3.5.0';
+let discordComponentsVersion = '^3.6.1';
 
 try {
   const packagePath = path.join(__dirname, '..', '..', 'package.json');

--- a/src/generator/index.tsx
+++ b/src/generator/index.tsx
@@ -8,7 +8,7 @@ import { buildProfiles } from '../utils/buildProfiles';
 import { scrollToMessage } from '../static/client';
 import { readFileSync } from 'fs';
 import path from 'path';
-import {renderToString} from "@derockdev/discord-components-core/hydrate";
+import { renderToString } from '@derockdev/discord-components-core/hydrate';
 
 // read the package.json file and get the @derockdev/discord-components-core version
 let discordComponentsVersion = '^3.5.0';
@@ -139,12 +139,12 @@ export default async function renderMessages({ messages, channel, callbacks, ...
         />
 
         {/* component library */}
-        {!options.ssr &&
+        {!options.ssr && (
           <script
             type="module"
             src={`https://cdn.jsdelivr.net/npm/@derockdev/discord-components-core@${discordComponentsVersion}/dist/derockdev-discord-components-core/derockdev-discord-components-core.esm.js`}
           ></script>
-        }
+        )}
       </head>
 
       <body

--- a/src/generator/index.tsx
+++ b/src/generator/index.tsx
@@ -143,8 +143,6 @@ export default async function renderMessages({ messages, channel, callbacks, ...
           <script
             type="module"
             src={`https://cdn.jsdelivr.net/npm/@derockdev/discord-components-core@${discordComponentsVersion}/dist/derockdev-discord-components-core/derockdev-discord-components-core.esm.js`}
-            // low priority if ssr is enabled
-            defer={options.ssr}
           ></script>
         )}
       </head>

--- a/src/generator/index.tsx
+++ b/src/generator/index.tsx
@@ -5,7 +5,7 @@ import { DiscordHeader, DiscordMessages } from '@derockdev/discord-components-re
 import renderMessage from './renderers/message';
 import renderContent, { RenderType } from './renderers/content';
 import { buildProfiles } from '../utils/buildProfiles';
-import { scrollToMessage } from '../static/client';
+import { revealSpoiler, scrollToMessage } from '../static/client';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { renderToString } from '@derockdev/discord-components-core/hydrate';
@@ -155,6 +155,8 @@ export default async function renderMessages({ messages, channel, callbacks, ...
       >
         {elements}
       </body>
+      {/* Make sure the script runs after the DOM has loaded */}
+      {options.ssr && <script dangerouslySetInnerHTML={{__html: revealSpoiler}}></script>}
     </html>
   );
 

--- a/src/generator/index.tsx
+++ b/src/generator/index.tsx
@@ -124,12 +124,6 @@ export default async function renderMessages({ messages, channel, callbacks, ...
         {/* title */}
         <title>{channel.isDMBased() ? 'Direct Messages' : channel.name}</title>
 
-        {/* profiles */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `window.$discordMessage={profiles:${JSON.stringify(await profiles)}}`,
-          }}
-        ></script>
 
         {/* message reference handler */}
         <script
@@ -138,13 +132,19 @@ export default async function renderMessages({ messages, channel, callbacks, ...
           }}
         />
 
-        {/* component library */}
-        {!options.ssr && (
+        {!options.ssr && <>
+          {/* profiles */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.$discordMessage={profiles:${JSON.stringify(await profiles)}}`,
+            }}
+          ></script>
+          {/* component library */}
           <script
             type="module"
             src={`https://cdn.jsdelivr.net/npm/@derockdev/discord-components-core@${discordComponentsVersion}/dist/derockdev-discord-components-core/derockdev-discord-components-core.esm.js`}
           ></script>
-        )}
+        </>}
       </head>
 
       <body

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export async function generateFromMessages<T extends ExportReturnType = ExportRe
     poweredBy: options.poweredBy ?? true,
     footerText: options.footerText ?? 'Exported {number} message{s}.',
     favicon: options.favicon ?? 'guild',
-    ssr: options.ssr ?? false,
+    hydrate: options.hydrate ?? false,
   });
 
   // get the time it took to render the messages

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export async function generateFromMessages<T extends ExportReturnType = ExportRe
     poweredBy: options.poweredBy ?? true,
     footerText: options.footerText ?? 'Exported {number} message{s}.',
     favicon: options.favicon ?? 'guild',
+    ssr: options.ssr ?? false,
   });
 
   // get the time it took to render the messages

--- a/src/static/client.ts
+++ b/src/static/client.ts
@@ -25,3 +25,6 @@ document.addEventListener('click', (e) => {
 */
 export const scrollToMessage =
   'document.addEventListener("click",t=>{let e=t.target;if(!e)return;let o=e?.getAttribute("data-goto");if(o){let r=document.getElementById(`m-${o}`);r?(r.scrollIntoView({behavior:"smooth",block:"center"}),r.style.backgroundColor="rgba(148, 156, 247, 0.1)",r.style.transition="background-color 0.5s ease",setTimeout(()=>{r.style.backgroundColor="transparent"},1e3)):console.warn("Message ${goto} not found.")}});';
+
+export const revealSpoiler =
+  'const s=document.querySelectorAll(".discord-spoiler");s.forEach(s=>s.addEventListener("click",()=>{if(s.classList.contains("discord-spoiler")){s.classList.remove("discord-spoiler");s.classList.add("discord-spoiler--revealed");}}));';

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,12 @@ export type GenerateFromMessagesOptions<T extends ExportReturnType> = Partial<{
    * @default "guild"
    */
   favicon: 'guild' | string;
+
+  /**
+   * Whether to hydrate the html server-side
+   * @default false - the returned html will be hydrated client-side
+   */
+  ssr: boolean;
 }>;
 
 export type CreateTranscriptOptions<T extends ExportReturnType> = Partial<

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type GenerateFromMessagesOptions<T extends ExportReturnType> = Partial<{
    * Whether to hydrate the html server-side
    * @default false - the returned html will be hydrated client-side
    */
-  ssr: boolean;
+  hydrate: boolean;
 }>;
 
 export type CreateTranscriptOptions<T extends ExportReturnType> = Partial<

--- a/src/utils/buildProfiles.ts
+++ b/src/utils/buildProfiles.ts
@@ -41,7 +41,7 @@ export async function buildProfiles(messages: Message[]) {
   }
 
   // return as a JSON
-  return JSON.stringify(profiles);
+  return profiles;
 }
 
 function buildProfile(member: GuildMember | null, author: User) {


### PR DESCRIPTION
### Reason

It is not ideal that the transcripts link to JS on a CDN. This means that, if the user is offline or does not have access to the CDN, then the transcript will not be hydrated and will be difficult to read.

This PR adds an option `ssr` when generating transcripts. If it is set to true, then the HTML will not contain the script tag that links to the CDN and will be hydrated server-side.

**NOTE**: this is intended to be merged after [this PR](https://github.com/ItzDerock/discord-components/pull/5), and the dependency version for `@derockdev/discord-components-core` and `@derockdev/discord-components-react` needs to be updated