### PR TITLE
fix: 🐛 Error when check if isThread() channel when use generateFromMessages()

### DIFF
--- a/src/generator/renderers/reply.tsx
+++ b/src/generator/renderers/reply.tsx
@@ -27,7 +27,7 @@ export default async function MessageReply({ message, context }: { message: Mess
       roleColor={referencedMessage.member?.displayHexColor ?? undefined}
       bot={!isCrosspost && referencedMessage.author.bot}
       verified={referencedMessage.author.flags?.has(UserFlags.VerifiedBot)}
-      op={message.channel.isThread() && referencedMessage.author.id === message.channel.ownerId}
+      op={message?.channel?.isThread?.() && referencedMessage.author.id === message?.channel?.ownerId}
       server={isCrosspost ?? undefined}
       command={isCommand}
     >


### PR DESCRIPTION
The channel is undefined in the object, which prevents it from working properly.

<img width="852" alt="image" src="https://github.com/ItzDerock/discord-html-transcripts/assets/71253960/cbf4b561-2657-4f93-8b46-972130ed3b6a">

To correct this problem, I've added optional chaining.