### PR TITLE
Added support for internal filtering with createTranscript method

### DIFF
--- a/docs/api-reference/createtranscript.md
+++ b/docs/api-reference/createtranscript.md
@@ -90,3 +90,11 @@ Defined in [discord.js](https://discord.js.org/#/docs/discord.js/main/typedef/Gu
 ### `options: CreateTranscriptOptions`
 
 The same options as [generatefrommessages.md](generatefrommessages.md 'mention') but adds the `limit` option which lets you limit set the number of messages to fetch.
+
+### `options.limit: number`
+
+The number of messages to fetch.
+
+### `options.filter: (message: Message<boolean>) => boolean`
+
+A function that will be called for each message to determine if it should be included in the transcript. If false, the message will not be included.

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
     lastMessageId = messages.lastKey();
 
     // if there are no more messages, break
-    if (filteredMessages.size < 100) break;
+    if (messages.size < 100) break;
 
     // if the limit has been reached, break
     if (allMessages.length >= resolvedLimit) break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,8 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
 
     // add the messages to the array
     allMessages.push(...filteredMessages.values());
-    lastMessageId = filteredMessages.lastKey();
+    // Get the last key of 'messages', not 'filteredMessages' because you will be refetching the same messages
+    lastMessageId = messages.lastKey();
 
     // if there are no more messages, break
     if (filteredMessages.size < 100) break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,9 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
   // fetch messages
   let allMessages: Message[] = [];
   let lastMessageId: string | undefined;
-  const { limit } = options;
+  const { limit, filter } = options;
   const resolvedLimit = typeof limit === 'undefined' || limit === -1 ? Infinity : limit;
+  const resolvedFilter = typeof filter === 'function' ? filter : (() => true);
 
   // until there are no more messages, keep fetching
   // eslint-disable-next-line no-constant-condition
@@ -109,13 +110,14 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
 
     // fetch messages
     const messages = await channel.messages.fetch(fetchLimitOptions);
+    const filteredMessages = messages.filter(resolvedFilter);
 
     // add the messages to the array
-    allMessages.push(...messages.values());
-    lastMessageId = messages.lastKey();
+    allMessages.push(...filteredMessages.values());
+    lastMessageId = filteredMessages.lastKey();
 
     // if there are no more messages, break
-    if (messages.size < 100) break;
+    if (filteredMessages.size < 100) break;
 
     // if the limit has been reached, break
     if (allMessages.length >= resolvedLimit) break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,6 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
   let lastMessageId: string | undefined;
   const { limit, filter } = options;
   const resolvedLimit = typeof limit === 'undefined' || limit === -1 ? Infinity : limit;
-  const resolvedFilter = typeof filter === 'function' ? filter : (() => true);
 
   // until there are no more messages, keep fetching
   // eslint-disable-next-line no-constant-condition
@@ -110,7 +109,7 @@ export async function createTranscript<T extends ExportReturnType = ExportReturn
 
     // fetch messages
     const messages = await channel.messages.fetch(fetchLimitOptions);
-    const filteredMessages = messages.filter(resolvedFilter);
+    const filteredMessages = typeof filter === 'function' ? messages.filter(filter) : messages;
 
     // add the messages to the array
     allMessages.push(...filteredMessages.values());

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { AttachmentBuilder } from 'discord.js';
+import type { AttachmentBuilder, Message } from 'discord.js';
 import type { RenderMessageContext } from './generator';
 
 export type AttachmentTypes = 'audio' | 'video' | 'image' | 'file';
@@ -72,5 +72,11 @@ export type CreateTranscriptOptions<T extends ExportReturnType> = Partial<
      * The max amount of messages to fetch. Use `-1` to recursively fetch.
      */
     limit: number;
+
+    /**
+     * Filter messages of the channel
+     * @default (() => true)
+     */
+    filter: (message: Message<boolean>) => boolean;
   }
 >;

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -23,7 +23,7 @@ client.on('ready', async () => {
 
   const attachment = await createTranscript(channel, {
     // Filter bot messages
-    filter: (message) => !message.author.bot
+    filter: (message) => !message.author.bot,
   });
 
   console.timeEnd('transcript');

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -4,8 +4,10 @@ import { createTranscript } from '../src';
 import { config } from 'dotenv';
 config();
 
+const { GuildMessages, Guilds, MessageContent } = discord.GatewayIntentBits;
+
 const client = new discord.Client({
-  intents: [discord.IntentsBitField.Flags.GuildMessages, discord.IntentsBitField.Flags.Guilds],
+  intents: [GuildMessages, Guilds, MessageContent],
 });
 
 client.on('ready', async () => {
@@ -18,7 +20,12 @@ client.on('ready', async () => {
   }
 
   console.time('transcript');
-  const attachment = await createTranscript(channel);
+
+  const attachment = await createTranscript(channel, {
+    // Filter bot messages
+    filter: (message) => !message.author.bot
+  });
+
   console.timeEnd('transcript');
 
   await channel.send({


### PR DESCRIPTION
With this PR, you're able to directly filter messages with the `createTranscript` method without the need of having to fetch and filter messages yourself and parse them into the `generateFromMessages` method.

I have:
- Updated and tested typings
- Updated and tested `createTranscript`

Tested Code:
```typescript
  const attachment = await createTranscript(channel, {
    // Filter bot messages
    filter: (message) => !message.author.bot
  });
  ```
  
The below attachment is the result of the above tested code. You can see that the only messages are from me and the attachment (of the actual channel in Discord) shows the same messages but including Dyno, a bot, which I am filtering out in the test.
![TranscriptLog](https://github.com/ItzDerock/discord-html-transcripts/assets/169464425/b2796ee4-e136-4463-b565-bb8ff59ecedd)
