### PR TITLE
Update plural system to fit multiple languages

### DIFF
--- a/src/generator/transcript.tsx
+++ b/src/generator/transcript.tsx
@@ -55,7 +55,7 @@ export default async function DiscordMessages({ messages, channel, callbacks, ..
         {options.footerText
           ? options.footerText
               .replaceAll('{number}', messages.length.toString())
-              .replace('{s}', messages.length > 1 ? 's' : '')
+              .replaceAll('{s}', messages.length > 1 ? 's' : '')
           : `Exported ${messages.length} message${messages.length > 1 ? 's' : ''}.`}{' '}
         {options.poweredBy ? (
           <span style={{ textAlign: 'center' }}>


### PR DESCRIPTION
This change permits to replace all the iterations of "{s}" present in the footer message so it can fit with other languages like French.

Example:

5 message{s} exporté{s}.