### PR TITLE
fix: invalid semicolon in transcript

### DIFF
--- a/src/generator/transcript.tsx
+++ b/src/generator/transcript.tsx
@@ -16,7 +16,7 @@ import { globalStyles } from './renderers/components/styles';
 export default async function DiscordMessages({ messages, channel, callbacks, ...options }: RenderMessageContext) {
   return (
     <DiscordMessagesComponent style={{ minHeight: '100vh' }}>
-      <style dangerouslySetInnerHTML={{ __html: globalStyles }} />;
+      <style dangerouslySetInnerHTML={{ __html: globalStyles }} />
       <DiscordHeader
         guild={channel.isDMBased() ? 'Direct Messages' : channel.guild.name}
         channel={


### PR DESCRIPTION
When generating a transcript, there was a semicolon at the very beginning of the generation. The problem has been fixed.