### PR TITLE
fix: move debug from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/react-dom": "^19.1.9",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
-    "debug": "^4.4.1",
     "discord.js": "^14.22.1",
     "dotenv": "^17.2.2",
     "eslint": "^9.35.0",
@@ -57,6 +56,7 @@
   "dependencies": {
     "@derockdev/discord-components-core": "^3.6.1",
     "@derockdev/discord-components-react": "^3.6.1",
+    "debug": "^4.4.1",
     "discord-markdown-parser": "~1.2.0",
     "react": "19.1.1",
     "react-dom": "19.1.1",


### PR DESCRIPTION
Fixes #196

## Problem
The `debug` module was incorrectly placed in `devDependencies`, causing "Cannot find module 'debug'" errors when the package is installed from pnpm. This broke version 3.3.0 for all users.

## Solution
Moved `debug` from `devDependencies` to `dependencies` since it's imported and used in [src/downloader/images.ts](cci:7://file///d:/Projects/contribution/discord-html-transcripts/src/downloader/images.ts:0:0-0:0).

## Testing
- Tested locally by building the package with pnpm
- Verified the fix works in a Discord bot using the transcript generation feature
- Confirmed the module is now properly included when installed via pnpm