### PR TITLE
Fix XSS vulnerability via javascript: protocol in links

### DIFF
--- a/src/generator/renderers/content.tsx
+++ b/src/generator/renderers/content.tsx
@@ -96,20 +96,24 @@ export async function MessageSingleASTNode({ node, context }: { node: SingleASTN
     case 'text':
       return node.content;
 
-    case 'link':
+    case 'link': {
+      const safeHref = /^https?:\/\//i.test(node.target) ? node.target : '#';
       return (
-        <a href={node.target}>
+        <a href={safeHref}>
           <MessageASTNodes nodes={node.content} context={context} />
         </a>
       );
+    }
 
     case 'url':
-    case 'autolink':
+    case 'autolink': {
+      const safeHref = /^https?:\/\//i.test(node.target) ? node.target : '#';
       return (
-        <a href={node.target} target="_blank" rel="noreferrer">
+        <a href={safeHref} target="_blank" rel="noreferrer">
           <MessageASTNodes nodes={node.content} context={context} />
         </a>
       );
+    }
 
     case 'blockQuote':
       if (context.type === RenderType.REPLY) {


### PR DESCRIPTION
## Summary

- Sanitize URLs in the `link`, `url`, and `autolink` AST node handlers in `src/generator/renderers/content.tsx` to only allow `http:` and `https:` protocols
- Malicious Discord messages like `[click me](javascript:alert(document.cookie))` would previously render as executable `javascript:` hrefs in transcript HTML; they now render as `#`

## Test plan

- [ ] Verify that normal `http://` and `https://` links still render correctly in transcripts
- [ ] Verify that `[text](javascript:alert(1))` links render with `href="#"` instead of the javascript URI
- [ ] Verify that autolinked URLs (`https://example.com`) still work as expected
- [ ] Run `pnpm run typecheck` — passes with no errors